### PR TITLE
Issue 8: MariaDB 10.4 and 10.5 support

### DIFF
--- a/10.4/default.cnf
+++ b/10.4/default.cnf
@@ -1,0 +1,27 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+# Use multi-byte UTF (utf8mb4) encoding by default (supports emojis, Asian symbols, mathematical symbols, etc.)
+character_set_server = utf8mb4
+collation_server = utf8mb4_unicode_ci
+init_connect = 'SET NAMES utf8mb4'
+
+# Set innodb as default
+default_storage_engine = InnoDB
+
+innodb_buffer_pool_size = 256M
+innodb_log_buffer_size = 8M
+innodb_log_file_size = 128MB
+
+innodb_file_per_table = 1
+
+# See https://github.com/docksal/service-db/pull/1
+#innodb_file_format = Barracuda
+#innodb_large_prefix = 1
+
+# Max packets
+max_allowed_packet = 128M

--- a/10.4/mysql-variables.txt
+++ b/10.4/mysql-variables.txt
@@ -1,0 +1,18 @@
+character_set_client	utf8mb4
+character_set_connection	utf8mb4
+character_set_database	utf8mb4
+character_set_filesystem	binary
+character_set_results	utf8mb4
+character_set_server	utf8mb4
+character_set_system	utf8
+collation_connection	utf8mb4_general_ci
+collation_database	utf8mb4_unicode_ci
+collation_server	utf8mb4_unicode_ci
+default_storage_engine	InnoDB
+init_connect	SET NAMES utf8mb4
+innodb_buffer_pool_size	268435456
+innodb_file_per_table	ON
+innodb_flush_log_at_trx_commit	1
+innodb_log_buffer_size	8388608
+innodb_log_file_size	134217728
+max_allowed_packet	134217728

--- a/10.5/default.cnf
+++ b/10.5/default.cnf
@@ -1,0 +1,27 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+# Use multi-byte UTF (utf8mb4) encoding by default (supports emojis, Asian symbols, mathematical symbols, etc.)
+character_set_server = utf8mb4
+collation_server = utf8mb4_unicode_ci
+init_connect = 'SET NAMES utf8mb4'
+
+# Set innodb as default
+default_storage_engine = InnoDB
+
+innodb_buffer_pool_size = 256M
+innodb_log_buffer_size = 8M
+innodb_log_file_size = 128MB
+
+innodb_file_per_table = 1
+
+# See https://github.com/docksal/service-db/pull/1
+#innodb_file_format = Barracuda
+#innodb_large_prefix = 1
+
+# Max packets
+max_allowed_packet = 128M

--- a/10.5/mysql-variables.txt
+++ b/10.5/mysql-variables.txt
@@ -1,0 +1,18 @@
+character_set_client	utf8mb4
+character_set_connection	utf8mb4
+character_set_database	utf8mb4
+character_set_filesystem	binary
+character_set_results	utf8mb4
+character_set_server	utf8mb4
+character_set_system	utf8
+collation_connection	utf8mb4_general_ci
+collation_database	utf8mb4_unicode_ci
+collation_server	utf8mb4_unicode_ci
+default_storage_engine	InnoDB
+init_connect	SET NAMES utf8mb4
+innodb_buffer_pool_size	268435456
+innodb_file_per_table	ON
+innodb_flush_log_at_trx_commit	1
+innodb_log_buffer_size	8388608
+innodb_log_file_size	134217728
+max_allowed_packet	134217728

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include env_make
 
-FROM ?= mariadb:10.3
-VERSION ?= 10.3
+FROM ?= mariadb:10.4
+VERSION ?= 10.4
 BUILD_TAG ?= $(VERSION)
 SOFTWARE_VERSION ?= $(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include env_make
 
-FROM ?= mariadb:10.4
-VERSION ?= 10.4
+FROM ?= mariadb:10.5
+VERSION ?= 10.5
 BUILD_TAG ?= $(VERSION)
 SOFTWARE_VERSION ?= $(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
 ## Versions
 
 - `docksal/mariadb:10.2`
-- `docksal/mariadb:10.3`, `docksal/mariadb:latest`
+- `docksal/mariadb:10.3`
+- `docksal/mariadb:10.4`
+- `docksal/mariadb:10.5`, `docksal/mariadb:latest`


### PR DESCRIPTION
# Changes

- Adds support for MariaDB versions 10.4 and 10.5.
- Version 10.5 becomes latest.

Fixes #8.