### PR TITLE
MariaDB 10.11

### DIFF
--- a/.github/scripts/docker-tag-delete.sh
+++ b/.github/scripts/docker-tag-delete.sh
@@ -18,7 +18,7 @@ if [[ "${1}" == "" ]]; then
 	exit 1
 else
 	# Split image:tag
-	IFS=$':' read IMAGE TAG <<< ${1};
+	IFS=$':' read IMAGE TAG <<< "${1}";
 	# Remove registry prefix from image if present
 	IMAGE=${IMAGE#"docker.io/"}
 fi
@@ -42,4 +42,4 @@ output=$(curl -sI "https://hub.docker.com/v2/repositories/${IMAGE}/tags/${TAG}/"
 )
 
 # Return and error if HTTP response code is not 204
-echo "${output}" | grep "HTTP/1.1 204 NO CONTENT"
+echo "${output}" | grep -i "HTTP/1.1 204 No Content"

--- a/.github/scripts/docker-tags.sh
+++ b/.github/scripts/docker-tags.sh
@@ -9,7 +9,7 @@
 # Declare expected variables
 IMAGE=${IMAGE} # docksal/cli
 VERSION_PREFIX=${VERSION_PREFIX} # php
-VERSION=${VERSION} # 7.4
+VERSION=${VERSION} # 8.1
 VERSION_SUFFIX=${VERSION_SUFFIX} # ide
 REGISTRY="${REGISTRY}" # ghcr.io
 GITHUB_REF=${GITHUB_REF} # refs/heads/develop, refs/heads/master, refs/tags/v1.0.0
@@ -35,7 +35,7 @@ set_output() {
 	# Print with new lines for output in build logs
 	(IFS=$'\n'; echo "${outputArr[*]}")
 	# Using newlines in output variables does not seem to work, so we'll use comas
-	(IFS=$','; echo "::set-output name=tags::${outputArr[*]}")
+	(IFS=$','; echo tags="${outputArr[*]}" | tee -a ${GITHUB_OUTPUT})
 }
 
 # Image tags

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -18,12 +18,13 @@ defaults:
 
 env:
   IMAGE: docksal/mariadb
+  LATEST_VERSION: "10.11"
   #DOCKSAL_VERSION: develop
 
 jobs:
   build:
     name: "Build: ${{ matrix.version }}/${{ matrix.arch }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
@@ -64,7 +65,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Environment variables
         run: |
@@ -73,24 +74,12 @@ jobs:
           echo BUILD_IMAGE_TAG="${IMAGE}:${VERSION_PREFIX}${VERSION}-build" | tee -a ${GITHUB_ENV}
           # Pull the host public SSH key at runtime instead of relying on a static value stored in secrets.
           echo ARM64_HOST_SSH_CERT="$(ssh-keyscan -t rsa ${{ secrets.ARM64_HOST }} 2>/dev/null)" | tee -a ${GITHUB_ENV}
-#      -
-#        # Switch docker context to a remote arm64 host
-#        # Used for building heavy images that take too long to build using QEMU + for native arm64 testing.
-#        name: Switch to arm64 builder host
-#        if: ${{ env.ARCH == 'arm64' }}
-#        uses: arwynfr/actions-docker-context@v2
-#        with:
-#          docker_host: "ssh://ubuntu@${{ secrets.ARM64_HOST }}"
-#          context_name: arm64-host
-#          ssh_key: "${{ secrets.ARM64_HOST_SSH_KEY }}"
-#          ssh_cert: "${{ env.ARM64_HOST_SSH_CERT }}"
-#          use_context: true
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Check Docker
         run: |
@@ -98,14 +87,14 @@ jobs:
           docker info
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         # Build and cache image in the registry
         name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ${{ env.BUILD_DIR }}
           file: ${{ env.BUILD_DIR }}/Dockerfile
@@ -122,7 +111,7 @@ jobs:
 
   test:
     name: "Test: ${{ matrix.version }}/${{ matrix.arch }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     strategy:
@@ -165,12 +154,10 @@ jobs:
     steps:
       -
         name: Setup Bats
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: "1.3.0"
+        uses: bats-core/bats-action@2.0.0
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Environment variables
         run: |
@@ -180,32 +167,10 @@ jobs:
           # Pull the host public SSH key at runtime instead of relying on a static value stored in secrets.
           echo ARM64_HOST_SSH_CERT="$(ssh-keyscan -t rsa ${{ secrets.ARM64_HOST }} 2>/dev/null)" | tee -a ${GITHUB_ENV}
       -
-        # Switch docker context to a remote arm64 host
-        # Used for building heavy images that take too long to build using QEMU + for native arm64 testing.
-        name: Switch to arm64 builder host
-        if: ${{ env.ARCH == 'arm64' }}
-        uses: arwynfr/actions-docker-context@v2
-        with:
-          docker_host: "ssh://ubuntu@${{ secrets.ARM64_HOST }}"
-          context_name: arm64-host
-          ssh_key: "${{ secrets.ARM64_HOST_SSH_KEY }}"
-          ssh_cert: "${{ env.ARM64_HOST_SSH_CERT }}"
-          use_context: true
-      -
         name: Check Docker
         run: |
           docker version
           docker info
-#      -
-#        name: Test preparations
-#        working-directory: ${{ env.BUILD_CONTEXT }}
-#        env:
-#          BUILD_IMAGE_TAG: ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-${{ env.ARCH }}
-#        run: |
-#          # Install Docksal using the passed DOCKSAL_VERSION value
-#          curl -sSL http://get.docksal.io | bash
-#          # Start the service using the build image tag
-#          make start
       -
         # Run tests
         name: Test
@@ -222,14 +187,16 @@ jobs:
       # Dynamic variable names cannot be used when mapping step outputs to job outputs.
       # Step outputs cannot be accessed directly from other jobs. Dead end.
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ env.GIT_SHA7 }}-${{ env.VERSION_PREFIX }}${{ env.VERSION }}-${{ env.ARCH }}
           path: ${{ github.workspace }}/test-results-*.txt
+          if-no-files-found: error
+          overwrite: true
 
   push:
     name: "Push: ${{ matrix.version }}/multi"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Wait for test to either succeed or fail
     needs: test
@@ -250,27 +217,26 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Environment variables
         run: |
           # Export variables for further steps
           echo GIT_SHA7="${GITHUB_SHA:0:7}" | tee -a ${GITHUB_ENV}
           echo BUILD_IMAGE_TAG="${IMAGE}:${VERSION_PREFIX}${VERSION}-build" | tee -a ${GITHUB_ENV}
-          # Pull the host public SSH key at runtime instead of relying on a static value stored in secrets.
-          echo ARM64_HOST_SSH_CERT="$(ssh-keyscan -t rsa ${{ secrets.ARM64_HOST }} 2>/dev/null)" | tee -a ${GITHUB_ENV}
       -
         # Login to Docker Hub
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Retrieve test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: test-results
+          pattern: test-results-${{ env.GIT_SHA7 }}-*
+          merge-multiple: true
       -
         # Generate persistent tags (edge, stable, release)
         name: Docker image tags
@@ -307,5 +273,5 @@ jobs:
             docker manifest push ${tag}
           done
           # Clean up intermediate arch-specific image tags (DockerHub only)
-          .github/scripts/docker-tag-delete.sh ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-amd64
-          .github/scripts/docker-tag-delete.sh ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-arm64
+          .github/scripts/docker-tag-delete.sh "${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-amd64"
+          .github/scripts/docker-tag-delete.sh "${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-arm64"

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -114,8 +114,9 @@ jobs:
           provenance: false
           sbom: false
           # BUILD_IMAGE_TAG - persistent multi-arch tag, updated at the end of the build (success or failure)
-          cache-from: type=registry,ref=${{ env.BUILD_IMAGE_TAG }}
-          cache-to: type=inline # Write the cache metadata into the image configuration
+          # Use registry cache with max mode to cahce all image layers in the registry
+          cache-from: type=registry,ref=${{ env.BUILD_IMAGE_TAG }}-cache-${{ env.ARCH }}
+          cache-to: type=registry,ref=${{ env.BUILD_IMAGE_TAG }}-cache-${{ env.ARCH }},mode=max
 
   test:
     name: "Test: ${{ matrix.version }}/${{ matrix.arch }}"

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -47,6 +47,12 @@ jobs:
           -
             arch: arm64
             version: "10.6"
+          -
+            arch: amd64
+            version: "10.11"
+          -
+            arch: arm64
+            version: "10.11"
 
     env:
       ARCH: ${{ matrix.arch }}
@@ -144,6 +150,12 @@ jobs:
 #          -
 #            arch: arm64
 #            version: "10.6"
+          -
+            arch: amd64
+            version: "10.11"
+#          -
+#            arch: arm64
+#            version: "10.11"
 
     env:
       ARCH: ${{ matrix.arch }}
@@ -229,6 +241,7 @@ jobs:
           - "10.4"
           - "10.5"
           - "10.6"
+          - "10.11"
 
     env:
       VERSION_PREFIX: ""

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -105,6 +105,14 @@ jobs:
           # Push intermediate arch-specific build tag to repo
           tags: ${{ env.BUILD_IMAGE_TAG }}-${{ env.GIT_SHA7 }}-${{ env.ARCH }}
           push: ${{ github.event_name != 'pull_request' }} # Don't push for PRs
+          # Disable automatic image attestations
+          # With image attestations enabled, the image tag pushed to the registry is a manifest list.
+          # That makes it impossible to stitch different platform images together in a manifest list, since you 
+          # cannot have a manifest list of manifest lists.
+          # See https://docs.docker.com/build/attestations/attestation-storage/
+          # TODO: Refactor to allow for image attestations
+          provenance: false
+          sbom: false
           # BUILD_IMAGE_TAG - persistent multi-arch tag, updated at the end of the build (success or failure)
           cache-from: type=registry,ref=${{ env.BUILD_IMAGE_TAG }}
           cache-to: type=inline # Write the cache metadata into the image configuration

--- a/10.11/default.cnf
+++ b/10.11/default.cnf
@@ -1,0 +1,24 @@
+[mysqld]
+# Force utf8mb4 (multi-byte UTF) encoding (supports emojis, Asian symbols, mathematical symbols, etc.)
+# Starting with mariadb 10.5, character-set-server and collation-server can only be set via command line arguments.
+#character-set-server = utf8mb4
+#collation-server = utf8mb4_unicode_ci
+
+# Always use server character set settings
+skip-character-set-client-handshake
+
+# Set innodb as default
+default_storage_engine = InnoDB
+
+innodb_buffer_pool_size = 256M
+innodb_log_buffer_size = 8M
+innodb_log_file_size = 128MB
+
+innodb_file_per_table = 1
+
+# See https://github.com/docksal/service-db/pull/1
+#innodb_file_format = Barracuda
+#innodb_large_prefix = 1
+
+# Max packets
+max_allowed_packet = 128M

--- a/10.11/mysql-variables.txt
+++ b/10.11/mysql-variables.txt
@@ -1,0 +1,17 @@
+character_set_client	utf8mb4
+character_set_connection	utf8mb4
+character_set_database	utf8mb4
+character_set_filesystem	binary
+character_set_results	utf8mb4
+character_set_server	utf8mb4
+character_set_system	utf8mb3
+collation_connection	utf8mb4_unicode_ci
+collation_database	utf8mb4_unicode_ci
+collation_server	utf8mb4_unicode_ci
+default_storage_engine	InnoDB
+innodb_buffer_pool_size	268435456
+innodb_file_per_table	ON
+innodb_flush_log_at_trx_commit	1
+innodb_log_buffer_size	8388608
+innodb_log_file_size	134217728
+max_allowed_packet	134217728

--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
 
 - `docksal/mariadb:10.4`
 - `docksal/mariadb:10.5`
-- `docksal/mariadb:10.6`, `docksal/mariadb:latest`
+- `docksal/mariadb:10.6` (LTS)
+- `docksal/mariadb:10.11` (LTS), `docksal/mariadb:latest`


### PR DESCRIPTION
- Added MariaDB v10.11 (LTS)
- Updated GitHub Actions
  - Various version updates
  - Disable automatic image attestations, which break our multi-platform image stitching process
  - Switched to registry cache for builds (fixes build caching)

Closes #22